### PR TITLE
feat(iammember): add iammember.Resolver interface

### DIFF
--- a/iamexample/members.go
+++ b/iamexample/members.go
@@ -3,7 +3,7 @@ package iamexample
 import (
 	"context"
 
-	"go.einride.tech/iam/iamspanner"
+	"go.einride.tech/iam/iammember"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -12,26 +12,26 @@ import (
 // MemberHeader is the gRPC header used by the example server to determine IAM members of the caller.
 const MemberHeader = "x-iam-example-members"
 
-// NewMemberHeaderResolver returns an iamspanner.MemberResolver that resolves members from MemberHeader.
-func NewMemberHeaderResolver() iamspanner.MemberResolver {
-	return &memberHeaderResolver{}
+// NewIAMMemberHeaderResolver returns an iammember.Resolver that resolves members from MemberHeader.
+func NewIAMMemberHeaderResolver() iammember.Resolver {
+	return &iamMemberHeaderResolver{}
 }
 
-var _ iamspanner.MemberResolver = &memberHeaderResolver{}
+var _ iammember.Resolver = &iamMemberHeaderResolver{}
 
-type memberHeaderResolver struct{}
+type iamMemberHeaderResolver struct{}
 
-// ResolveMember implements iamspanner.MemberResolver.
-func (m *memberHeaderResolver) ResolveMember(ctx context.Context) (string, error) {
+// ResolveIAMMembers implements iammember.Resolver.
+func (m *iamMemberHeaderResolver) ResolveIAMMembers(ctx context.Context) ([]string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", status.Errorf(codes.Unauthenticated, "missing members header: %s", MemberHeader)
+		return nil, status.Errorf(codes.Unauthenticated, "missing members header: %s", MemberHeader)
 	}
 	values := md.Get(MemberHeader)
 	if len(values) == 0 {
-		return "", status.Errorf(codes.Unauthenticated, "missing members header: %s", MemberHeader)
+		return nil, status.Errorf(codes.Unauthenticated, "missing members header: %s", MemberHeader)
 	}
-	return values[0], nil
+	return values, nil
 }
 
 // WithOutgoingMembers appends the provided members to the outgoing gRPC context.

--- a/iamexample/server_test.go
+++ b/iamexample/server_test.go
@@ -55,7 +55,7 @@ func (ts *serverTestSuite) newTestFixture(t *testing.T) *serverTestFixture {
 	iamServer, err := iamspanner.NewServer(
 		spannerClient,
 		roles,
-		NewMemberHeaderResolver(),
+		NewIAMMemberHeaderResolver(),
 		iamspanner.ServerConfig{
 			ErrorHook: func(ctx context.Context, err error) {
 				t.Log(err)

--- a/iammember/doc.go
+++ b/iammember/doc.go
@@ -1,0 +1,2 @@
+// Package iammember provides primitives for IAM member identifiers.
+package iammember

--- a/iammember/resolver.go
+++ b/iammember/resolver.go
@@ -1,0 +1,8 @@
+package iammember
+
+import "context"
+
+// Resolver resolves the IAM member identifiers for a caller context.
+type Resolver interface {
+	ResolveIAMMembers(context.Context) ([]string, error)
+}

--- a/iamspanner/server_test.go
+++ b/iamspanner/server_test.go
@@ -75,8 +75,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -97,8 +97,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -132,8 +132,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -162,8 +162,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -201,8 +201,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -243,8 +243,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -270,8 +270,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -309,8 +309,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -349,8 +349,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user2, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user2}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -388,8 +388,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -428,8 +428,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -451,8 +451,8 @@ func TestServer(t *testing.T) {
 		server, err := NewServer(
 			newDatabase(),
 			roles,
-			memberResolver(func(ctx context.Context) (string, error) {
-				return user1, nil
+			iamMemberResolver(func(ctx context.Context) ([]string, error) {
+				return []string{user1}, nil
 			}),
 			ServerConfig{
 				ErrorHook: func(ctx context.Context, err error) {
@@ -487,8 +487,8 @@ func TestServer(t *testing.T) {
 	})
 }
 
-type memberResolver func(context.Context) (string, error)
+type iamMemberResolver func(context.Context) ([]string, error)
 
-func (r memberResolver) ResolveMember(ctx context.Context) (string, error) {
+func (r iamMemberResolver) ResolveIAMMembers(ctx context.Context) ([]string, error) {
 	return r(ctx)
 }


### PR DESCRIPTION
Resolves multiple members from the caller context. Multiple members are
valid when the caller should get permissions from multiple members, such
as group memberships.
