### PR TITLE
feat(iamgooglemember): add standard UserInfo resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ spanner-generate:
 go-mod-tidy:
 	$(info [$@] tidying Go module files...)
 	@go mod tidy
+	@cd cmd/iamctl && go mod tidy
 
 .PHONY: go-test
 go-test:

--- a/iamexample/members.go
+++ b/iamexample/members.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"go.einride.tech/iam/iammember"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 // MemberHeader is the gRPC header used by the example server to determine IAM members of the caller.
@@ -25,13 +23,9 @@ type iamMemberHeaderResolver struct{}
 func (m *iamMemberHeaderResolver) ResolveIAMMembers(ctx context.Context) (context.Context, []string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, nil, status.Errorf(codes.Unauthenticated, "missing members header: %s", MemberHeader)
+		return ctx, nil, nil
 	}
-	values := md.Get(MemberHeader)
-	if len(values) == 0 {
-		return nil, nil, status.Errorf(codes.Unauthenticated, "missing members header: %s", MemberHeader)
-	}
-	return ctx, values, nil
+	return ctx, md.Get(MemberHeader), nil
 }
 
 // WithOutgoingMembers appends the provided members to the outgoing gRPC context.

--- a/iammember/iamgooglemember/doc.go
+++ b/iammember/iamgooglemember/doc.go
@@ -1,0 +1,2 @@
+// Package iamgooglemember provides primitives for resolving IAM members from Google ID tokens.
+package iamgooglemember

--- a/iammember/iamgooglemember/issuer.go
+++ b/iammember/iamgooglemember/issuer.go
@@ -1,0 +1,4 @@
+package iamgooglemember
+
+// Issuer is the issuer of Google ID tokens.
+const Issuer = "accounts.google.com"

--- a/iammember/iamgooglemember/userinfo.go
+++ b/iammember/iamgooglemember/userinfo.go
@@ -1,0 +1,106 @@
+package iamgooglemember
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// UserInfo from a Google ID token.
+//
+// See: https://developers.google.com/identity/protocols/oauth2/openid-connect
+type UserInfo struct {
+	// Issuer is an identifier for the Issuer of the response.
+	// Always https://accounts.google.com or accounts.google.com for Google ID tokens.
+	Issuer string `json:"iss,omitempty"`
+	// ClientID of the authorized presenter.
+	// This claim is only needed when the party requesting the ID token is not the same as the audience of the ID token.
+	// This may be the case at Google for hybrid apps where a web application and Android app have a different OAuth 2.0
+	// client ID but share the same Google APIs project.
+	ClientID string `json:"azp,omitempty"`
+	// Audience that this ID token is intended for.
+	Audience string `json:"aud,omitempty"`
+	// Subject is an identifier for the user, unique among all Google accounts and never reused.
+	Subject string `json:"sub,omitempty"`
+	// HostedDomain is the hosted G Suite domain of the user. Provided only if the user belongs to a hosted domain.
+	HostedDomain string `json:"hd,omitempty"`
+	// Email is user's email address. May be unset.
+	Email string `json:"email,omitempty"`
+	// EmailVerified is true if the user's e-mail address has been verified; otherwise false.
+	EmailVerified bool `json:"email_verified,omitempty"`
+	// AccessTokenHash provides validation that the access token is tied to the identity token.
+	// If the ID token is issued with an access token value in the server flow, this claim is always included.
+	// This claim can be used as an alternate mechanism to protect against cross-site request forgery attacks,
+	// but if you use CSRF it is not necessary to verify the access token.
+	AccessTokenHash string `json:"at_hash,omitempty"`
+	// Name is the user's full name, in a displayable form.
+	// When name claims are present, you can use them to update your app's user records.
+	// Note that this claim is never guaranteed to be present.
+	Name string `json:"name,omitempty"`
+	// Picture is the URL of the user's profile picture.
+	// When picture claims are present, you can use them to update your app's user records.
+	// Note that this claim is never guaranteed to be present.
+	Picture string `json:"picture,omitempty"`
+	// GivenName is the user's given name(s) or first name(s). Might be provided when a name claim is present.
+	GivenName string `json:"given_name,omitempty"`
+	// FamilyName is the user's surname(s) or last name(s). Might be provided when a name claim is present.
+	FamilyName string `json:"family_name,omitempty"`
+	// The user's locale, represented by a BCP 47 language tag. Might be provided when a name claim is present.
+	Locale string `json:"locale,omitempty"`
+	// IssuedAt is the time the ID token was issued.
+	// Represented in Unix time (integer seconds).
+	IssuedAt int64 `json:"iat,omitempty"`
+	// Expires is the expiration time on or after which the ID token must not be accepted.
+	// Represented in Unix time (integer seconds).
+	Expires int64 `json:"exp,omitempty"`
+	// JWTID is the JWT ID of the ID token.
+	JWTID string `json:"jti,omitempty"`
+}
+
+// Validate returns an error if the UserInfo is missing any required fields or has invalid values for known fields.
+func (u *UserInfo) Validate() error {
+	if u.Issuer == "" {
+		return fmt.Errorf("validate user info: missing required field: 'iss'")
+	}
+	if u.Audience == "" {
+		return fmt.Errorf("validate user info: missing required field: 'aud'")
+	}
+	if u.Expires == 0 {
+		return fmt.Errorf("validate user info: missing required field: 'exp'")
+	}
+	if u.IssuedAt == 0 {
+		return fmt.Errorf("validate user info: missing required field: 'iat'")
+	}
+	if u.Subject == "" {
+		return fmt.Errorf("validate user info: missing required field: 'sub'")
+	}
+	if strings.TrimPrefix(u.Issuer, "https://") != Issuer {
+		return fmt.Errorf("validate: unsupported issuer '%s'", u.Issuer)
+	}
+	return nil
+}
+
+// UnmarshalBase64 unmarshals the UserInfo from the provided Base64-URL-encoded string.
+func (u *UserInfo) UnmarshalBase64(value string) error {
+	decoder := json.NewDecoder(base64.NewDecoder(base64.RawURLEncoding, strings.NewReader(value)))
+	if err := decoder.Decode(u); err != nil {
+		return fmt.Errorf("unmarshal Google user info from base64: %w", err)
+	}
+	if err := u.Validate(); err != nil {
+		return fmt.Errorf("unmarshal Google user info from base64: %w", err)
+	}
+	return nil
+}
+
+// UnmarshalJWT unmarshals the UserInfo from the provided JWT token.
+func (u *UserInfo) UnmarshalJWT(token string) error {
+	s := strings.Split(token, ".")
+	if len(s) < 2 {
+		return fmt.Errorf("unmarshal user info from JWT: invalid token")
+	}
+	if err := u.UnmarshalBase64(s[1]); err != nil {
+		return fmt.Errorf("unmarshal user info from JWT: %w", err)
+	}
+	return nil
+}

--- a/iammember/iamgooglemember/userinforesolver.go
+++ b/iammember/iamgooglemember/userinforesolver.go
@@ -1,0 +1,8 @@
+package iamgooglemember
+
+import "context"
+
+// UserInfoResolver resolves IAM members from Google ID token UserInfo.
+type UserInfoResolver interface {
+	ResolveIAMMembersFromGoogleUserInfo(context.Context, *UserInfo) (context.Context, []string, error)
+}

--- a/iammember/iamgooglemember/userinforesolver_authorizationheader.go
+++ b/iammember/iamgooglemember/userinforesolver_authorizationheader.go
@@ -1,0 +1,44 @@
+package iamgooglemember
+
+import (
+	"context"
+	"strings"
+
+	"go.einride.tech/iam/iammember"
+	"google.golang.org/grpc/metadata"
+)
+
+// ResolveAuthorizationHeader returns an iammember.Resolver that uses the provided UserInfoResolver
+// to resolve IAM members from the standard authorization header.
+func ResolveAuthorizationHeader(userInfoResolver UserInfoResolver) iammember.Resolver {
+	return authorizationHeaderResolver{userInfoResolver: userInfoResolver}
+}
+
+type authorizationHeaderResolver struct {
+	userInfoResolver UserInfoResolver
+}
+
+// ResolveIAMMembers implements iammember.Resolver.
+func (a authorizationHeaderResolver) ResolveIAMMembers(ctx context.Context) (context.Context, []string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx, nil, nil
+	}
+	values := md.Get("authorization")
+	if len(values) == 0 {
+		return ctx, nil, nil
+	}
+	authorization := values[0]
+	indexOfSpace := strings.IndexByte(authorization, ' ')
+	if indexOfSpace == -1 {
+		return ctx, nil, nil
+	}
+	if !strings.EqualFold(authorization[:indexOfSpace], "bearer") {
+		return ctx, nil, nil
+	}
+	var userInfo UserInfo
+	if err := userInfo.UnmarshalJWT(authorization[indexOfSpace+1:]); err != nil {
+		return nil, nil, err
+	}
+	return a.userInfoResolver.ResolveIAMMembersFromGoogleUserInfo(ctx, &userInfo)
+}

--- a/iammember/iamgooglemember/userinforesolver_userinfoheader.go
+++ b/iammember/iamgooglemember/userinforesolver_userinfoheader.go
@@ -1,0 +1,48 @@
+package iamgooglemember
+
+import (
+	"context"
+
+	"go.einride.tech/iam/iammember"
+	"google.golang.org/grpc/metadata"
+)
+
+// Known UserInfo headers.
+const (
+	GoogleCloudEndpointUserInfoHeader   = "x-endpoint-api-userinfo"
+	GoogleCloudAPIGatewayUserInfoHeader = "x-apigateway-api-userinfo"
+)
+
+// ResolveUserInfoHeader returns an iammember.Resolver that uses the provided UserInfoResolver
+// to resolve IAM members from a UserInfo header.
+func ResolveUserInfoHeader(header string, userInfoResolver UserInfoResolver) iammember.Resolver {
+	return userInfoHeaderResolver{
+		header:           header,
+		userInfoResolver: userInfoResolver,
+	}
+}
+
+type userInfoHeaderResolver struct {
+	header           string
+	userInfoResolver UserInfoResolver
+}
+
+// ResolveIAMMembers implements iammember.Resolver.
+func (u userInfoHeaderResolver) ResolveIAMMembers(ctx context.Context) (context.Context, []string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx, nil, nil
+	}
+	if !ok {
+		return ctx, nil, nil
+	}
+	values := md.Get(u.header)
+	if len(values) == 0 {
+		return ctx, nil, nil
+	}
+	var userInfo UserInfo
+	if err := userInfo.UnmarshalBase64(values[0]); err != nil {
+		return nil, nil, err
+	}
+	return u.userInfoResolver.ResolveIAMMembersFromGoogleUserInfo(ctx, &userInfo)
+}


### PR DESCRIPTION
Pluggable resolution of IAM members from Google ID token UserInfo.
Members can be resolved from the primary authorization header, or
secondary UserInfo headers (when using a gateway such as Cloud Endpoints
or API Gateway).
