### PR TITLE
iamauthz middleware

### DIFF
--- a/iamauthz/doc.go
+++ b/iamauthz/doc.go
@@ -1,0 +1,2 @@
+// Package iamauthz provides primitives for performing IAM request authorization.
+package iamauthz

--- a/iamauthz/middleware.go
+++ b/iamauthz/middleware.go
@@ -1,0 +1,79 @@
+package iamauthz
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Authorize marks the current request as processed by an authorization check.
+// WithAuthorization must have been called on the context for the call to be effective.
+//
+// Authorize should be called at the start of an authorization check, to ensure that any errors resulting from the
+// authorization check itself are forwarded to the caller.
+func Authorize(ctx context.Context) {
+	if value, ok := ctx.Value(contextKey{}).(*contextValue); ok {
+		value.mu.Lock()
+		value.authorized = true
+		value.mu.Unlock()
+	}
+}
+
+// RequireUnaryAuthorization is a grpc.UnaryServerInterceptor that requires authorization
+// to be performed on all incoming requests.
+//
+// To mark the request as processed by authorization checks, the method implementing authorization should call
+// Authorize on the request context as soon as authorization starts.
+func RequireUnaryAuthorization(
+	ctx context.Context,
+	req interface{},
+	_ *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	ctx = WithAuthorization(ctx)
+	resp, err := handler(ctx, req)
+	if code := status.Code(err); code == codes.Unauthenticated || code == codes.PermissionDenied {
+		return nil, err
+	}
+	value := ctx.Value(contextKey{}).(*contextValue)
+	value.mu.Lock()
+	authorized := value.authorized
+	value.mu.Unlock()
+	if !authorized {
+		return nil, status.Error(codes.Internal, "server did not perform authorization")
+	}
+	return resp, err
+}
+
+var _ grpc.UnaryServerInterceptor = RequireUnaryAuthorization
+
+// RequireStreamAuthorization is a grpc.StreamServerInterceptor that aborts all incoming streams, pending implementation
+// of stream support in this package.
+func RequireStreamAuthorization(
+	_ interface{},
+	_ grpc.ServerStream,
+	_ *grpc.StreamServerInfo,
+	_ grpc.StreamHandler,
+) error {
+	return status.Error(codes.Internal, "server has not implemented stream authorization")
+}
+
+var _ grpc.StreamServerInterceptor = RequireStreamAuthorization
+
+// WithAuthorization adds authorization to the current request context.
+func WithAuthorization(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(contextKey{}).(*contextValue); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey{}, &contextValue{})
+}
+
+type contextKey struct{}
+
+type contextValue struct {
+	mu         sync.Mutex
+	authorized bool
+}

--- a/iamauthz/middleware_test.go
+++ b/iamauthz/middleware_test.go
@@ -1,0 +1,119 @@
+package iamauthz
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"gotest.tools/v3/assert"
+
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestRequireUnaryAuthorization(t *testing.T) {
+	t.Run("authorized", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "localhost:0")
+		assert.NilError(t, err)
+		grpcServer := grpc.NewServer(grpc.UnaryInterceptor(RequireUnaryAuthorization))
+		healthpb.RegisterHealthServer(grpcServer, &authorizedHealthServer{})
+		errChan := make(chan error)
+		go func() {
+			if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+				errChan <- err
+				return
+			}
+			errChan <- nil
+		}()
+		t.Cleanup(func() {
+			assert.NilError(t, <-errChan)
+		})
+		t.Cleanup(func() {
+			grpcServer.GracefulStop()
+		})
+		ctx := withTestDeadline(context.Background(), t)
+		conn, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+		assert.NilError(t, err)
+		client := healthpb.NewHealthClient(conn)
+		response, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.NilError(t, err)
+		assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.GetStatus())
+	})
+
+	t.Run("not authorized", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "localhost:0")
+		assert.NilError(t, err)
+		grpcServer := grpc.NewServer(grpc.UnaryInterceptor(RequireUnaryAuthorization))
+		healthpb.RegisterHealthServer(grpcServer, &healthServer{})
+		errChan := make(chan error)
+		go func() {
+			if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+				errChan <- err
+				return
+			}
+			errChan <- nil
+		}()
+		t.Cleanup(func() {
+			assert.NilError(t, <-errChan)
+		})
+		t.Cleanup(func() {
+			grpcServer.GracefulStop()
+		})
+		ctx := withTestDeadline(context.Background(), t)
+		conn, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+		assert.NilError(t, err)
+		client := healthpb.NewHealthClient(conn)
+		response, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.Assert(t, response == nil)
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+}
+
+type authorizedHealthServer struct {
+	healthServer
+}
+
+func (s *authorizedHealthServer) Check(
+	ctx context.Context,
+	request *healthpb.HealthCheckRequest,
+) (*healthpb.HealthCheckResponse, error) {
+	Authorize(ctx)
+	return s.healthServer.Check(ctx, request)
+}
+
+func (s *authorizedHealthServer) Watch(
+	request *healthpb.HealthCheckRequest,
+	server healthpb.Health_WatchServer,
+) error {
+	Authorize(server.Context())
+	return s.healthServer.Watch(request, server)
+}
+
+type healthServer struct{}
+
+func (s *healthServer) Check(
+	_ context.Context,
+	_ *healthpb.HealthCheckRequest,
+) (*healthpb.HealthCheckResponse, error) {
+	return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+}
+
+func (s *healthServer) Watch(
+	_ *healthpb.HealthCheckRequest,
+	_ healthpb.Health_WatchServer,
+) error {
+	return nil
+}
+
+func withTestDeadline(ctx context.Context, t *testing.T) context.Context {
+	deadline, ok := t.Deadline()
+	if !ok {
+		return ctx
+	}
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/iamexample/authorization.go
+++ b/iamexample/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.einride.tech/aip/resourcename"
+	"go.einride.tech/iam/iamauthz"
 	"go.einride.tech/iam/iamresource"
 	"go.einride.tech/iam/iamspanner"
 	iamexamplev1 "go.einride.tech/iam/proto/gen/einride/iam/example/v1"
@@ -26,6 +27,7 @@ func (a *Authorization) GetShipper(
 	ctx context.Context,
 	request *iamexamplev1.GetShipperRequest,
 ) (*iamexamplev1.Shipper, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shippers.get"
 	if err := a.require(ctx, permission, request.GetName()); err != nil {
 		return nil, err
@@ -37,6 +39,7 @@ func (a *Authorization) ListShippers(
 	ctx context.Context,
 	request *iamexamplev1.ListShippersRequest,
 ) (*iamexamplev1.ListShippersResponse, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shippers.list"
 	if err := a.require(ctx, permission, iamresource.Root); err != nil {
 		return nil, err
@@ -48,6 +51,7 @@ func (a *Authorization) CreateShipper(
 	ctx context.Context,
 	request *iamexamplev1.CreateShipperRequest,
 ) (*iamexamplev1.Shipper, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shippers.create"
 	if err := a.require(ctx, permission, iamresource.Root); err != nil {
 		return nil, err
@@ -59,6 +63,7 @@ func (a *Authorization) UpdateShipper(
 	ctx context.Context,
 	request *iamexamplev1.UpdateShipperRequest,
 ) (*iamexamplev1.Shipper, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shippers.update"
 	if err := a.require(ctx, permission, request.GetShipper().GetName()); err != nil {
 		return nil, err
@@ -70,6 +75,7 @@ func (a *Authorization) DeleteShipper(
 	ctx context.Context,
 	request *iamexamplev1.DeleteShipperRequest,
 ) (*iamexamplev1.Shipper, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shippers.delete"
 	if err := a.require(ctx, permission, request.GetName()); err != nil {
 		return nil, err
@@ -81,6 +87,7 @@ func (a *Authorization) GetSite(
 	ctx context.Context,
 	request *iamexamplev1.GetSiteRequest,
 ) (*iamexamplev1.Site, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.get"
 	if err := a.require(ctx, permission, request.GetName()); err != nil {
 		return nil, err
@@ -92,6 +99,7 @@ func (a *Authorization) ListSites(
 	ctx context.Context,
 	request *iamexamplev1.ListSitesRequest,
 ) (*iamexamplev1.ListSitesResponse, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.list"
 	if err := a.require(ctx, permission, request.GetParent()); err != nil {
 		return nil, err
@@ -103,6 +111,7 @@ func (a *Authorization) CreateSite(
 	ctx context.Context,
 	request *iamexamplev1.CreateSiteRequest,
 ) (*iamexamplev1.Site, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.create"
 	if err := a.require(ctx, permission, request.GetParent()); err != nil {
 		return nil, err
@@ -114,6 +123,7 @@ func (a *Authorization) UpdateSite(
 	ctx context.Context,
 	request *iamexamplev1.UpdateSiteRequest,
 ) (*iamexamplev1.Site, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.update"
 	if err := a.require(ctx, permission, request.GetSite().GetName()); err != nil {
 		return nil, err
@@ -125,6 +135,7 @@ func (a *Authorization) DeleteSite(
 	ctx context.Context,
 	request *iamexamplev1.DeleteSiteRequest,
 ) (*iamexamplev1.Site, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.delete"
 	if err := a.require(ctx, permission, request.GetName()); err != nil {
 		return nil, err
@@ -136,6 +147,7 @@ func (a *Authorization) BatchGetSites(
 	ctx context.Context,
 	request *iamexamplev1.BatchGetSitesRequest,
 ) (*iamexamplev1.BatchGetSitesResponse, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.get"
 	if request.Parent != "" {
 		if ok, err := a.test(ctx, permission, request.Parent); err != nil {
@@ -154,6 +166,7 @@ func (a *Authorization) SearchSites(
 	ctx context.Context,
 	request *iamexamplev1.SearchSitesRequest,
 ) (*iamexamplev1.SearchSitesResponse, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.sites.get"
 	if request.Parent != "" {
 		if ok, err := a.test(ctx, permission, request.Parent); err != nil {
@@ -180,6 +193,7 @@ func (a *Authorization) GetShipment(
 	ctx context.Context,
 	request *iamexamplev1.GetShipmentRequest,
 ) (*iamexamplev1.Shipment, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shipments.get"
 	if err := a.require(ctx, permission, request.GetName()); err != nil {
 		return nil, err
@@ -191,6 +205,7 @@ func (a *Authorization) ListShipments(
 	ctx context.Context,
 	request *iamexamplev1.ListShipmentsRequest,
 ) (*iamexamplev1.ListShipmentsResponse, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shipments.list"
 	if err := a.require(ctx, permission, request.GetParent()); err != nil {
 		return nil, err
@@ -202,6 +217,7 @@ func (a *Authorization) CreateShipment(
 	ctx context.Context,
 	request *iamexamplev1.CreateShipmentRequest,
 ) (*iamexamplev1.Shipment, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shipments.create"
 	if err := a.require(ctx, permission, request.GetParent()); err != nil {
 		return nil, err
@@ -213,6 +229,7 @@ func (a *Authorization) UpdateShipment(
 	ctx context.Context,
 	request *iamexamplev1.UpdateShipmentRequest,
 ) (*iamexamplev1.Shipment, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shipments.update"
 	ok, err := a.test(ctx, permission, request.GetShipment().GetName())
 	if err != nil {
@@ -237,6 +254,7 @@ func (a *Authorization) DeleteShipment(
 	ctx context.Context,
 	request *iamexamplev1.DeleteShipmentRequest,
 ) (*iamexamplev1.Shipment, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shipments.delete"
 	if err := a.require(ctx, permission, request.GetName()); err != nil {
 		return nil, err
@@ -248,6 +266,7 @@ func (a *Authorization) BatchGetShipments(
 	ctx context.Context,
 	request *iamexamplev1.BatchGetShipmentsRequest,
 ) (*iamexamplev1.BatchGetShipmentsResponse, error) {
+	iamauthz.Authorize(ctx)
 	const permission = "freight.shipments.get"
 	if request.Parent != "" {
 		if ok, err := a.test(ctx, permission, request.Parent); err != nil {
@@ -280,6 +299,7 @@ func (a *Authorization) SetIamPolicy(
 	ctx context.Context,
 	request *iam.SetIamPolicyRequest,
 ) (*iam.Policy, error) {
+	iamauthz.Authorize(ctx)
 	var permission string
 	switch {
 	case request.Resource == iamresource.Root:
@@ -303,6 +323,7 @@ func (a *Authorization) GetIamPolicy(
 	ctx context.Context,
 	request *iam.GetIamPolicyRequest,
 ) (*iam.Policy, error) {
+	iamauthz.Authorize(ctx)
 	var permission string
 	switch {
 	case request.Resource == iamresource.Root:
@@ -326,6 +347,7 @@ func (a *Authorization) TestIamPermissions(
 	ctx context.Context,
 	request *iam.TestIamPermissionsRequest,
 ) (*iam.TestIamPermissionsResponse, error) {
+	iamauthz.Authorize(ctx)
 	return a.Next.TestIamPermissions(ctx, request)
 }
 

--- a/iamexample/server_test.go
+++ b/iamexample/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"go.einride.tech/aip/resourcename"
+	"go.einride.tech/iam/iamauthz"
 	"go.einride.tech/iam/iamexample/iamexampledata"
 	"go.einride.tech/iam/iamregistry"
 	"go.einride.tech/iam/iamspanner"
@@ -78,7 +79,7 @@ func (ts *serverTestSuite) newTestFixture(t *testing.T) *serverTestFixture {
 	}
 	lis, err := net.Listen("tcp", "localhost:0")
 	assert.NilError(t, err)
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(iamauthz.RequireUnaryAuthorization))
 	iamexamplev1.RegisterFreightServiceServer(grpcServer, serverWithAuthorization)
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
As a belt-and-suspenders approach to ensure that authorization has been
performed on all RPC methods in a service, this middleware requires
authorization implementations to call `iamauthz.Authorize(ctx)` to mark
the request as authorized.

Requests that return without being marked as authorized are stopped by
the middleware, instead returning INTERNAL (signaling that the
implementer of the RPC method has not correctly implemented
authorization).