### PR TITLE
chore: add iamctl to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: gomod
+    directory: /cmd/iamctl
+    schedule:
+      interval: daily


### PR DESCRIPTION
This is a separate module to encapsulate the CLI-specific dependencies.
