### PR TITLE
fix: allow camelCase in permission service names

### DIFF
--- a/iampermission/match_test.go
+++ b/iampermission/match_test.go
@@ -75,6 +75,13 @@ func TestMatch(t *testing.T) {
 			rhs:      "pubsub.subscriptions.foo",
 			expected: false,
 		},
+
+		{
+			name:     "camelCase",
+			lhs:      "pubsub.fooSubscriptions.create",
+			rhs:      "pubsub.fooSubscriptions.create",
+			expected: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, Match(tt.lhs, tt.rhs))

--- a/iampermission/validate.go
+++ b/iampermission/validate.go
@@ -78,7 +78,7 @@ func isValidSegment(segment string) bool {
 				return false
 			}
 		default:
-			if !unicode.In(r, unicode.Lower, unicode.Digit) {
+			if !unicode.In(r, unicode.Lower, unicode.Upper, unicode.Digit) {
 				return false
 			}
 		}

--- a/iampermission/validate_test.go
+++ b/iampermission/validate_test.go
@@ -36,9 +36,8 @@ func TestValidate(t *testing.T) {
 		},
 
 		{
-			name:          "camelCase segment",
-			permission:    "pubsub.awesomeStuff.consume",
-			errorContains: "invalid resource segment",
+			name:       "camelCase segment",
+			permission: "pubsub.awesomeStuff.consume",
 		},
 
 		{


### PR DESCRIPTION
In accordance with:

https://cloud.google.com/iam/docs/understanding-roles#predefined_roles
