### PR TITLE
fix: correctly handle missing long-running operations authorization

### DIFF
--- a/iamreflect/iamdescriptor.go
+++ b/iamreflect/iamdescriptor.go
@@ -97,7 +97,7 @@ func NewIAMDescriptor(service protoreflect.ServiceDescriptor, files *protoregist
 		}
 	}
 	// Resolve long-running operation authorization operations.
-	for _, operationPermissions := range result.LongRunningOperationsAuthorization.OperationPermissions {
+	for _, operationPermissions := range result.LongRunningOperationsAuthorization.GetOperationPermissions() {
 		if len(operationPermissions.Operation.GetPattern()) > 0 {
 			// Operation is annotated with patterns manually. No need to resolve.
 			continue


### PR DESCRIPTION
The Get-functions handle when the receiver is nil.
