### PR TITLE
feat(iamspanner): simplify API

### DIFF
--- a/iamregistry/roles_test.go
+++ b/iamregistry/roles_test.go
@@ -1,0 +1,32 @@
+package iamregistry
+
+import (
+	"testing"
+
+	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
+	"google.golang.org/genproto/googleapis/iam/admin/v1"
+	"gotest.tools/v3/assert"
+)
+
+func TestRoles_RangeRolesByPermission(t *testing.T) {
+	t.Run("wildcard", func(t *testing.T) {
+		roles, err := NewRoles(&iamv1.Roles{
+			Role: []*admin.Role{
+				{
+					Name:                "roles/test.admin",
+					Title:               "Test admin",
+					Description:         "Test description",
+					IncludedPermissions: []string{"test.*"},
+				},
+			},
+		})
+		assert.NilError(t, err)
+		var found bool
+		roles.RangeRolesByPermission("test.foo.bar", func(role *admin.Role) bool {
+			assert.Equal(t, "roles/test.admin", role.Name)
+			found = true
+			return true
+		})
+		assert.Assert(t, found)
+	})
+}

--- a/iamspanner/server_bindings_read.go
+++ b/iamspanner/server_bindings_read.go
@@ -1,0 +1,166 @@
+package iamspanner
+
+import (
+	"context"
+
+	"cloud.google.com/go/spanner"
+	"go.einride.tech/aip/resourcename"
+	"go.einride.tech/iam/iamresource"
+	"go.einride.tech/iam/iamspanner/iamspannerdb"
+	"google.golang.org/genproto/googleapis/iam/admin/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ReadBindingsByResourcesAndMembers reads all roles bound to the provided members and resources.
+func (s *IAMServer) ReadBindingsByResourcesAndMembers(
+	ctx context.Context,
+	resources []string,
+	members []string,
+	fn func(ctx context.Context, resource string, role *admin.Role, member string) error,
+) error {
+	tx := s.client.Single()
+	defer tx.Close()
+	return s.ReadBindingsByResourcesAndMembersInTransaction(ctx, tx, resources, members, fn)
+}
+
+// ReadBindingsByResourcesAndMembersInTransaction reads all roles bound to members and resources
+// within the provided Spanner transaction.
+// Also considers roles bound to parent resources.
+func (s *IAMServer) ReadBindingsByResourcesAndMembersInTransaction(
+	ctx context.Context,
+	tx ReadTransaction,
+	resources []string,
+	members []string,
+	fn func(ctx context.Context, resource string, role *admin.Role, member string) error,
+) error {
+	// Deduplicate resources and parents to read.
+	resourcesAndParents := make(map[string]struct{}, len(resources))
+	// Include root resource.
+	resourcesAndParents[iamresource.Root] = struct{}{}
+	for _, resource := range resources {
+		if resource == iamresource.Root {
+			continue
+		}
+		if !resourcename.ContainsWildcard(resource) {
+			resourcesAndParents[resource] = struct{}{}
+		}
+		resourcename.RangeParents(resource, func(parent string) bool {
+			if !resourcename.ContainsWildcard(parent) {
+				resourcesAndParents[parent] = struct{}{}
+			}
+			return true
+		})
+	}
+	// Build deduplicated key ranges to read.
+	memberResourceKeySets := make([]spanner.KeySet, 0, len(resources))
+	for resource := range resourcesAndParents {
+		for _, member := range members {
+			memberResourceKeySets = append(memberResourceKeySets, spanner.Key{member, resource}.AsPrefix())
+		}
+	}
+	iamPolicyBindings := iamspannerdb.Descriptor().IamPolicyBindings()
+	iamPolicyBindingsByMemberAndResource := iamspannerdb.Descriptor().IamPolicyBindingsByMemberAndResource()
+	return tx.ReadWithOptions(
+		ctx,
+		iamPolicyBindings.TableName(),
+		spanner.KeySets(memberResourceKeySets...),
+		[]string{
+			iamPolicyBindingsByMemberAndResource.Resource().ColumnName(),
+			iamPolicyBindingsByMemberAndResource.Role().ColumnName(),
+			iamPolicyBindingsByMemberAndResource.Member().ColumnName(),
+		},
+		&spanner.ReadOptions{
+			Index: iamPolicyBindingsByMemberAndResource.IndexName(),
+		},
+	).Do(func(r *spanner.Row) error {
+		var resource string
+		if err := r.Column(0, &resource); err != nil {
+			return err
+		}
+		var roleName string
+		if err := r.Column(1, &roleName); err != nil {
+			return err
+		}
+		role, ok := s.roles.FindRoleByName(roleName)
+		if !ok {
+			return status.Errorf(codes.Internal, "missing built-in role: %s", roleName)
+		}
+		var member string
+		if err := r.Column(2, &member); err != nil {
+			return err
+		}
+		return fn(ctx, resource, role, member)
+	})
+}
+
+// ReadBindingsByMembersAndPermissions reads all bindings for the provided members and permissions.
+func (s *IAMServer) ReadBindingsByMembersAndPermissions(
+	ctx context.Context,
+	members []string,
+	permissions []string,
+	fn func(ctx context.Context, resource string, role *admin.Role, member string) error,
+) error {
+	tx := s.client.Single()
+	defer tx.Close()
+	return s.ReadBindingsByMembersAndPermissionsInTransaction(ctx, tx, members, permissions, fn)
+}
+
+// ReadBindingsByMembersAndPermissionsInTransaction reads all bindings for the provided members and permissions,
+// within the provided Spanner transaction.
+func (s *IAMServer) ReadBindingsByMembersAndPermissionsInTransaction(
+	ctx context.Context,
+	tx ReadTransaction,
+	members []string,
+	permissions []string,
+	fn func(ctx context.Context, resource string, role *admin.Role, member string) error,
+) error {
+	memberRoleKeySets := make([]spanner.KeySet, 0, len(members)*len(permissions))
+	for _, member := range members {
+		for _, permission := range permissions {
+			s.roles.RangeRolesByPermission(permission, func(role *admin.Role) bool {
+				for _, existingKeySet := range memberRoleKeySets {
+					existingKey := existingKeySet.(spanner.KeyRange).Start
+					if member == existingKey[0] && role.Name == existingKey[1].(string) {
+						return true // already have this member and role
+					}
+				}
+				memberRoleKeySets = append(memberRoleKeySets, spanner.Key{member, role.Name}.AsPrefix())
+				return true
+			})
+		}
+	}
+	iamPolicyBindings := iamspannerdb.Descriptor().IamPolicyBindings()
+	iamPolicyBindingsByMemberAndRole := iamspannerdb.Descriptor().IamPolicyBindingsByMemberAndRole()
+	return tx.ReadWithOptions(
+		ctx,
+		iamPolicyBindings.TableName(),
+		spanner.KeySets(memberRoleKeySets...),
+		[]string{
+			iamPolicyBindingsByMemberAndRole.Resource().ColumnName(),
+			iamPolicyBindingsByMemberAndRole.Role().ColumnName(),
+			iamPolicyBindingsByMemberAndRole.Member().ColumnName(),
+		},
+		&spanner.ReadOptions{
+			Index: iamPolicyBindingsByMemberAndRole.IndexName(),
+		},
+	).Do(func(r *spanner.Row) error {
+		var resource string
+		if err := r.Column(0, &resource); err != nil {
+			return err
+		}
+		var roleName string
+		if err := r.Column(1, &roleName); err != nil {
+			return err
+		}
+		role, ok := s.roles.FindRoleByName(roleName)
+		if !ok {
+			return status.Errorf(codes.Internal, "missing built-in role: %s", roleName)
+		}
+		var member string
+		if err := r.Column(2, &member); err != nil {
+			return err
+		}
+		return fn(ctx, resource, role, member)
+	})
+}

--- a/iamspanner/server_permissions.go
+++ b/iamspanner/server_permissions.go
@@ -27,12 +27,12 @@ func (s *IAMServer) TestIamPermissions(
 	permissions := make(map[string]struct{}, len(request.Permissions))
 	tx := s.client.Single()
 	defer tx.Close()
-	if err := s.ReadRolesBoundToMembersAndResourcesInTransaction(
+	if err := s.ReadBindingsByResourcesAndMembersInTransaction(
 		ctx,
 		tx,
-		memberResolveResult.Members,
 		[]string{request.Resource},
-		func(ctx context.Context, _, _ string, role *admin.Role) error {
+		memberResolveResult.Members,
+		func(ctx context.Context, _ string, role *admin.Role, _ string) error {
 			for _, permission := range request.Permissions {
 				if s.roles.RoleHasPermission(role.Name, permission) {
 					permissions[permission] = struct{}{}

--- a/iamspanner/server_policies.go
+++ b/iamspanner/server_policies.go
@@ -1,0 +1,112 @@
+package iamspanner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+	"go.einride.tech/iam/iamspanner/iamspannerdb"
+	"google.golang.org/genproto/googleapis/iam/v1"
+)
+
+// ReadPolicyInTransaction reads the IAM policy for a resource within the provided transaction.
+func (s *IAMServer) ReadPolicyInTransaction(
+	ctx context.Context,
+	tx ReadTransaction,
+	resource string,
+) (*iam.Policy, error) {
+	var policy iam.Policy
+	var binding *iam.Binding
+	iamPolicyBindings := iamspannerdb.Descriptor().IamPolicyBindings()
+	if err := tx.Read(
+		ctx,
+		iamPolicyBindings.TableName(),
+		spanner.Key{resource}.AsPrefix(),
+		[]string{
+			iamPolicyBindings.BindingIndex().ColumnName(),
+			iamPolicyBindings.Role().ColumnName(),
+			iamPolicyBindings.Member().ColumnName(),
+		},
+	).Do(func(row *spanner.Row) error {
+		var bindingIndex int64
+		if err := row.Column(0, &bindingIndex); err != nil {
+			return err
+		}
+		var role string
+		if err := row.Column(1, &role); err != nil {
+			return err
+		}
+		var member string
+		if err := row.Column(2, &member); err != nil {
+			return err
+		}
+		if binding == nil || int(bindingIndex) >= len(policy.Bindings) {
+			binding = &iam.Binding{Role: role}
+			policy.Bindings = append(policy.Bindings, binding)
+		}
+		binding.Members = append(binding.Members, member)
+		return nil
+	}); err != nil {
+		return nil, s.handleStorageError(ctx, err)
+	}
+	etag, err := computeETag(&policy)
+	if err != nil {
+		return nil, err
+	}
+	policy.Etag = etag
+	return &policy, nil
+}
+
+// ReadWritePolicy enables the caller to modify a policy in a read-write transaction.
+func (s *IAMServer) ReadWritePolicy(
+	ctx context.Context,
+	resource string,
+	fn func(*iam.Policy) (*iam.Policy, error),
+) (*iam.Policy, error) {
+	var result *iam.Policy
+	if _, err := s.client.ReadWriteTransaction(
+		ctx,
+		func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+			policy, err := s.ReadPolicyInTransaction(ctx, tx, resource)
+			if err != nil {
+				return err
+			}
+			policy, err = fn(policy)
+			if err != nil {
+				return err
+			}
+			result = policy
+			mutations := []*spanner.Mutation{deleteIAMPolicyMutation(resource)}
+			mutations = append(mutations, insertIAMPolicyMutations(resource, policy)...)
+			return tx.BufferWrite(mutations)
+		},
+	); err != nil {
+		return nil, s.handleStorageError(ctx, err)
+	}
+	result.Etag = nil
+	etag, err := computeETag(result)
+	if err != nil {
+		return nil, err
+	}
+	result.Etag = etag
+	return result, nil
+}
+
+// ValidatePolicyFreshnessInTransaction validates the freshness of an IAM policy for a resource
+// within the provided transaction.
+func (s *IAMServer) ValidatePolicyFreshnessInTransaction(
+	ctx context.Context,
+	tx ReadTransaction,
+	resource string,
+	etag []byte,
+) (bool, error) {
+	if len(etag) == 0 {
+		return true, nil
+	}
+	existingPolicy, err := s.ReadPolicyInTransaction(ctx, tx, resource)
+	if err != nil {
+		return false, fmt.Errorf("validate freshness: %w", err)
+	}
+	return bytes.Equal(existingPolicy.Etag, etag), nil
+}

--- a/iamspanner/server_policies_get.go
+++ b/iamspanner/server_policies_get.go
@@ -19,7 +19,7 @@ func (s *IAMServer) GetIamPolicy(
 	}
 	tx := s.client.Single()
 	defer tx.Close()
-	return s.QueryIamPolicyInTransaction(ctx, tx, request.Resource)
+	return s.ReadPolicyInTransaction(ctx, tx, request.Resource)
 }
 
 func validateGetIamPolicyRequest(request *iam.GetIamPolicyRequest) error {

--- a/iamspanner/server_policies_set.go
+++ b/iamspanner/server_policies_set.go
@@ -23,7 +23,7 @@ func (s *IAMServer) SetIamPolicy(
 	}
 	var unfresh bool
 	if _, err := s.client.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
-		if ok, err := s.ValidateIamPolicyFreshnessInTransaction(
+		if ok, err := s.ValidatePolicyFreshnessInTransaction(
 			ctx, tx, request.GetResource(), request.GetPolicy().GetEtag(),
 		); err != nil {
 			return err


### PR DESCRIPTION
All methods that read bindings are now called Read(...) and all take a
callback on the exact same format (a callback for a single binding).

No more methods on the IAMServer are called Query(...).
