### PR TITLE
feat: add checksum to iammember.ResolveResult

### DIFF
--- a/cmd/iamctl/internal/examplecmd/exampleservercmd/server.go
+++ b/cmd/iamctl/internal/examplecmd/exampleservercmd/server.go
@@ -132,6 +132,7 @@ func (googleIDTokenMemberResolver) ResolveIAMMembers(ctx context.Context) (iamme
 	if !ok {
 		return result, nil
 	}
+	result.AddChecksum(authorizationKey, token)
 	var payload iamjwt.Payload
 	if err := payload.UnmarshalToken(token); err != nil {
 		return iammember.ResolveResult{}, err

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go/spanner v1.19.0
 	github.com/google/cel-go v0.7.3
+	github.com/google/go-cmp v0.5.6
 	go.einride.tech/aip v0.39.0
 	go.einride.tech/spanner-aip v0.34.0
 	google.golang.org/api v0.47.0

--- a/iamexample/members.go
+++ b/iamexample/members.go
@@ -27,6 +27,7 @@ func (m *iamMemberHeaderResolver) ResolveIAMMembers(ctx context.Context) (iammem
 		return result, nil
 	}
 	for _, member := range md.Get(MemberHeader) {
+		result.AddChecksum(MemberHeader, member)
 		result.Add(MemberHeader, member)
 	}
 	return result, nil

--- a/iammember/chain_test.go
+++ b/iammember/chain_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 )
 
@@ -25,7 +26,7 @@ func TestChainResolvers(t *testing.T) {
 		}
 		actual, err := ChainResolvers(constantResult(expected)).ResolveIAMMembers(context.Background())
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expected, actual)
+		assert.DeepEqual(t, expected, actual, cmpopts.IgnoreFields(ResolveResult{}, "Checksum"))
 	})
 
 	t.Run("multi", func(t *testing.T) {
@@ -38,20 +39,22 @@ func TestChainResolvers(t *testing.T) {
 		}
 		actual, err := ChainResolvers(
 			constantResult{
-				Members: []string{"foo", "bar"},
+				Checksum: 1,
+				Members:  []string{"foo", "bar"},
 				Metadata: Metadata{
 					"key1": {"foo", "bar"},
 				},
 			},
 			constantResult{
-				Members: []string{"baz"},
+				Checksum: 2,
+				Members:  []string{"baz"},
 				Metadata: Metadata{
 					"key2": {"baz"},
 				},
 			},
 		).ResolveIAMMembers(context.Background())
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expected, actual)
+		assert.DeepEqual(t, expected, actual, cmpopts.IgnoreFields(ResolveResult{}, "Checksum"))
 	})
 
 	t.Run("multi duplicates", func(t *testing.T) {
@@ -78,7 +81,7 @@ func TestChainResolvers(t *testing.T) {
 			},
 		).ResolveIAMMembers(context.Background())
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expected, actual)
+		assert.DeepEqual(t, expected, actual, cmpopts.IgnoreFields(ResolveResult{}, "Checksum"))
 	})
 
 	t.Run("error", func(t *testing.T) {


### PR DESCRIPTION
Can be used for determining if any of the tokens have changed, for
example to invalidate cached authorization information.
