### PR TITLE
feat: prefer []*admin.Role over *iamv1.Roles in public API

### DIFF
--- a/cmd/iamctl/internal/examplecmd/exampleservercmd/server.go
+++ b/cmd/iamctl/internal/examplecmd/exampleservercmd/server.go
@@ -15,7 +15,6 @@ import (
 	"go.einride.tech/iam/iamjwt"
 	"go.einride.tech/iam/iammember"
 	"go.einride.tech/iam/iammixin"
-	"go.einride.tech/iam/iamregistry"
 	"go.einride.tech/iam/iamspanner"
 	iamexamplev1 "go.einride.tech/iam/proto/gen/einride/iam/example/v1"
 	"google.golang.org/api/idtoken"
@@ -28,13 +27,9 @@ func newServer(spannerClient *spanner.Client) (*iamexample.Authorization, error)
 	if err != nil {
 		return nil, err
 	}
-	roles, err := iamregistry.NewRoles(iamDescriptor.PredefinedRoles)
-	if err != nil {
-		return nil, err
-	}
 	iamServer, err := iamspanner.NewIAMServer(
 		spannerClient,
-		roles,
+		iamDescriptor.PredefinedRoles.Role,
 		iammember.FromContextResolver(),
 		iamspanner.ServerConfig{
 			ErrorHook: func(ctx context.Context, err error) {

--- a/iamexample/server_test.go
+++ b/iamexample/server_test.go
@@ -10,7 +10,6 @@ import (
 	"go.einride.tech/aip/resourcename"
 	"go.einride.tech/iam/iamauthz"
 	"go.einride.tech/iam/iammember"
-	"go.einride.tech/iam/iamregistry"
 	"go.einride.tech/iam/iamspanner"
 	"go.einride.tech/iam/iamtest"
 	iamexamplev1 "go.einride.tech/iam/proto/gen/einride/iam/example/v1"
@@ -55,12 +54,10 @@ func newServerTestSuite(t *testing.T) *serverTestSuite {
 func (ts *serverTestSuite) newTestFixture(t *testing.T) *serverTestFixture {
 	iamDescriptor, err := iamexamplev1.NewFreightServiceIAMDescriptor()
 	assert.NilError(t, err)
-	roles, err := iamregistry.NewRoles(iamDescriptor.PredefinedRoles)
-	assert.NilError(t, err)
 	spannerClient := ts.spanner.NewDatabaseFromDDLFiles(t, "schema.sql", "../iamspanner/schema.sql")
 	iamServer, err := iamspanner.NewIAMServer(
 		spannerClient,
-		roles,
+		iamDescriptor.PredefinedRoles.Role,
 		iammember.FromContextResolver(),
 		iamspanner.ServerConfig{
 			ErrorHook: func(ctx context.Context, err error) {

--- a/iamregistry/roles.go
+++ b/iamregistry/roles.go
@@ -15,14 +15,14 @@ type Roles struct {
 }
 
 // NewRoles creates a set of Roles from a pre-defined roles annotation.
-func NewRoles(roles *iamv1.Roles) (*Roles, error) {
-	if err := iamreflect.ValidateRoles(roles); err != nil {
+func NewRoles(roles ...*admin.Role) (*Roles, error) {
+	if err := iamreflect.ValidateRoles(&iamv1.Roles{Role: roles}); err != nil {
 		return nil, fmt.Errorf("new roles registry: %w", err)
 	}
 	result := Roles{
-		roles: make(map[string]*admin.Role, len(roles.Role)),
+		roles: make(map[string]*admin.Role, len(roles)),
 	}
-	for _, role := range roles.Role {
+	for _, role := range roles {
 		result.roles[role.Name] = role
 	}
 	return &result, nil

--- a/iamregistry/roles_test.go
+++ b/iamregistry/roles_test.go
@@ -3,23 +3,20 @@ package iamregistry
 import (
 	"testing"
 
-	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	"google.golang.org/genproto/googleapis/iam/admin/v1"
 	"gotest.tools/v3/assert"
 )
 
 func TestRoles_RangeRolesByPermission(t *testing.T) {
 	t.Run("wildcard", func(t *testing.T) {
-		roles, err := NewRoles(&iamv1.Roles{
-			Role: []*admin.Role{
-				{
-					Name:                "roles/test.admin",
-					Title:               "Test admin",
-					Description:         "Test description",
-					IncludedPermissions: []string{"test.*"},
-				},
+		roles, err := NewRoles(
+			&admin.Role{
+				Name:                "roles/test.admin",
+				Title:               "Test admin",
+				Description:         "Test description",
+				IncludedPermissions: []string{"test.*"},
 			},
-		})
+		)
 		assert.NilError(t, err)
 		var found bool
 		roles.RangeRolesByPermission("test.foo.bar", func(role *admin.Role) bool {

--- a/iamspanner/server.go
+++ b/iamspanner/server.go
@@ -43,14 +43,18 @@ type ReadTransaction interface {
 // NewIAMServer creates a new Spanner IAM policy server.
 func NewIAMServer(
 	client *spanner.Client,
-	roles *iamregistry.Roles,
+	roles []*admin.Role,
 	memberResolver iammember.Resolver,
 	config ServerConfig,
 ) (*IAMServer, error) {
+	rolesRegistry, err := iamregistry.NewRoles(roles...)
+	if err != nil {
+		return nil, fmt.Errorf("new IAM server: %w", err)
+	}
 	s := &IAMServer{
 		client:         client,
 		config:         config,
-		roles:          roles,
+		roles:          rolesRegistry,
 		memberResolver: memberResolver,
 	}
 	return s, nil


### PR DESCRIPTION
Prefer using the standard type whenever possible, and let the rest be
internal implementation details.

BREAKING CHANGE: Creating a new Spanner IAM server now requires
                 []*admin.Role instead of *iamregistry.Roles.
