### PR TITLE
fix: mitigate unused variable

### DIFF
--- a/cmd/protoc-gen-go-iam/internal/geniam/authorization.go
+++ b/cmd/protoc-gen-go-iam/internal/geniam/authorization.go
@@ -220,6 +220,7 @@ func (c authorizationCodeGenerator) generateConstructor(g *protogen.GeneratedFil
 	g.P("if err != nil {")
 	g.P("return nil, ", fmtErrorf, `("new `, c.service.GoName, ` authorization: %w", err)`)
 	g.P("}")
+	g.P("_ = descriptor") // instead of figuring out if it will be used
 	g.P("var result ", c.StructGoName())
 	g.P("result.next = next")
 	for _, method := range c.service.Methods {

--- a/proto/gen/einride/iam/example/v1/freight_service_iam.pb.go
+++ b/proto/gen/einride/iam/example/v1/freight_service_iam.pb.go
@@ -242,6 +242,7 @@ func NewFreightServiceAuthorization(
 	if err != nil {
 		return nil, fmt.Errorf("new FreightService authorization: %w", err)
 	}
+	_ = descriptor
 	var result FreightServiceAuthorization
 	result.next = next
 	descriptorGetShipper, err := protoregistry.GlobalFiles.FindDescriptorByName("einride.iam.example.v1.FreightService.GetShipper")


### PR DESCRIPTION
When a service has only `none` or `custom` authorization, the descriptor
will be unused in the generated authorization constructor.

Adding an underscore assignment prevents this from halting compilation.
