### PR TITLE
feat: forward error codes from CEL functions

### DIFF
--- a/iamauthz/after.go
+++ b/iamauthz/after.go
@@ -73,7 +73,7 @@ func (a *AfterMethodAuthorization) AuthorizeRequestAndResponse(
 		"response": response,
 	})
 	if err != nil {
-		return nil, err
+		return nil, forwardErrorCodes(err)
 	}
 	boolVal, ok := val.Value().(bool)
 	if !ok {

--- a/iamauthz/before.go
+++ b/iamauthz/before.go
@@ -71,7 +71,7 @@ func (a *BeforeMethodAuthorization) AuthorizeRequest(
 		"request": request,
 	})
 	if err != nil {
-		return nil, err
+		return nil, forwardErrorCodes(err)
 	}
 	boolVal, ok := val.Value().(bool)
 	if !ok {

--- a/iamauthz/errors.go
+++ b/iamauthz/errors.go
@@ -1,0 +1,21 @@
+package iamauthz
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// forwardErrorCodes is a workaround for CEL custom functions not being able to return Go errors with gRPC codes.
+// Instead, the CEL functions are expected to return the status code as a prefix of the error.
+func forwardErrorCodes(err error) error {
+	errStr := err.Error()
+	for _, code := range []codes.Code{codes.InvalidArgument, codes.PermissionDenied} {
+		codeStr := code.String()
+		if strings.HasPrefix(errStr, codeStr) {
+			return status.Error(code, strings.TrimPrefix(strings.TrimPrefix(errStr, codeStr), ": "))
+		}
+	}
+	return err
+}

--- a/iamcel/test.go
+++ b/iamcel/test.go
@@ -11,6 +11,7 @@ import (
 	"go.einride.tech/iam/iampermission"
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/grpc/codes"
 )
 
 // TestFunction is the name of the test permission function.
@@ -52,7 +53,7 @@ func NewTestFunctionImplementation(
 			}
 			permission, ok := iampermission.ResolveMethodPermission(options, resource)
 			if !ok {
-				return types.NewErr("test: failed to resolve permission for resource '%s'", resource)
+				return types.NewErr("%s: no permission configured for resource '%s'", codes.PermissionDenied, resource)
 			}
 			// TODO: When cel-go supports async functions, use the caller context here.
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/iamcel/testall.go
+++ b/iamcel/testall.go
@@ -12,6 +12,7 @@ import (
 	"go.einride.tech/iam/iampermission"
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/grpc/codes"
 )
 
 // TestAllFunction is the name of the function for testing that all resources have a specified permission.
@@ -61,7 +62,9 @@ func NewTestAllFunctionImplementation(
 			for _, resource := range resources {
 				permission, ok := iampermission.ResolveMethodPermission(options, resource)
 				if !ok {
-					return types.NewErr("test: failed to resolve permission for resource '%s'", resource)
+					return types.NewErr(
+						"%s: no permission configured for resource '%s'", codes.InvalidArgument, resource,
+					)
 				}
 				resourcePermissions[resource] = permission
 			}

--- a/iamcel/testany.go
+++ b/iamcel/testany.go
@@ -12,6 +12,7 @@ import (
 	"go.einride.tech/iam/iampermission"
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/grpc/codes"
 )
 
 // TestAnyFunction is the name of the test_any permission function.
@@ -61,7 +62,9 @@ func NewTestAnyFunctionImplementation(
 			for _, resource := range resources {
 				permission, ok := iampermission.ResolveMethodPermission(options, resource)
 				if !ok {
-					return types.NewErr("test: failed to resolve permission '%s'", permission)
+					return types.NewErr(
+						"%s: no permission configured for resource '%s'", codes.InvalidArgument, resource,
+					)
 				}
 				resourcePermissions[resource] = permission
 			}

--- a/iamexample/server_iam_test.go
+++ b/iamexample/server_iam_test.go
@@ -1,0 +1,35 @@
+package iamexample
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genproto/googleapis/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gotest.tools/v3/assert"
+)
+
+func (ts *serverTestSuite) testIAM(t *testing.T) {
+	t.Parallel()
+	ctx := withTestDeadline(context.Background(), t)
+
+	t.Run("authorized", func(t *testing.T) {
+		t.Run("unconfigured resource", func(t *testing.T) {
+			const (
+				member  = "user:test@example.com"
+				shipper = "shippers/1234"
+			)
+			fx := ts.newTestFixture(t)
+			fx.iam.AddPolicyBinding(t, "/", "roles/freight.admin", member)
+			got, err := fx.client.GetIamPolicy(
+				WithOutgoingMembers(ctx, member),
+				&iam.GetIamPolicyRequest{
+					Resource: "resources/foo",
+				},
+			)
+			assert.Equal(t, codes.PermissionDenied, status.Code(err), "unexpected status: %v", err)
+			assert.Assert(t, got == nil)
+		})
+	})
+}

--- a/iamexample/server_test.go
+++ b/iamexample/server_test.go
@@ -39,6 +39,8 @@ func TestServer(t *testing.T) {
 	t.Run("BatchGetShipments", ts.testBatchGetShipments)
 	// long-running operations
 	t.Run("LongRunningOperations", ts.testLongRunningOperations)
+	// IAM
+	t.Run("IAM", ts.testIAM)
 }
 
 type serverTestSuite struct {


### PR DESCRIPTION
Prevents errors from CEL functions causing code Unknown at the API
level, which would trigger alerts.
