### PR TITLE
fix: forward status codes from permission test functions

### DIFF
--- a/iamauthz/errors.go
+++ b/iamauthz/errors.go
@@ -11,7 +11,12 @@ import (
 // Instead, the CEL functions are expected to return the status code as a prefix of the error.
 func forwardErrorCodes(err error) error {
 	errStr := err.Error()
-	for _, code := range []codes.Code{codes.InvalidArgument, codes.PermissionDenied} {
+	for _, code := range []codes.Code{
+		codes.InvalidArgument,
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.DeadlineExceeded,
+	} {
 		codeStr := code.String()
 		if strings.HasPrefix(errStr, codeStr) {
 			return status.Error(code, strings.TrimPrefix(strings.TrimPrefix(errStr, codeStr), ": "))

--- a/iamcel/test.go
+++ b/iamcel/test.go
@@ -12,6 +12,7 @@ import (
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestFunction is the name of the test permission function.
@@ -59,6 +60,9 @@ func NewTestFunctionImplementation(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			if result, err := tester.TestPermissions(ctx, caller, map[string]string{resource: permission}); err != nil {
+				if s, ok := status.FromError(err); ok {
+					return types.NewErr("%s: %s", s.Code(), s.Message())
+				}
 				return types.NewErr("test: error testing permission '%s': %v", permission, err)
 			} else if !result[resource] {
 				return types.False

--- a/iamcel/testall.go
+++ b/iamcel/testall.go
@@ -13,6 +13,7 @@ import (
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestAllFunction is the name of the function for testing that all resources have a specified permission.
@@ -72,6 +73,9 @@ func NewTestAllFunctionImplementation(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			if result, err := tester.TestPermissions(ctx, caller, resourcePermissions); err != nil {
+				if s, ok := status.FromError(err); ok {
+					return types.NewErr("%s: %s", s.Code(), s.Message())
+				}
 				return types.NewErr("test: error testing permission: %v", err)
 			} else {
 				if len(result) != len(resources) {

--- a/iamcel/testany.go
+++ b/iamcel/testany.go
@@ -13,6 +13,7 @@ import (
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestAnyFunction is the name of the test_any permission function.
@@ -72,6 +73,9 @@ func NewTestAnyFunctionImplementation(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			if result, err := tester.TestPermissions(ctx, caller, resourcePermissions); err != nil {
+				if s, ok := status.FromError(err); ok {
+					return types.NewErr("%s: %s", s.Code(), s.Message())
+				}
 				return types.NewErr("test: error testing permission: %v", err)
 			} else {
 				if len(result) != len(resources) {


### PR DESCRIPTION
When permission testing involves remote procedure calls, status codes
need to be forwarded through the CEL errors.
