### PR TITLE
fix: use Bearer, not bearer for tokens

### DIFF
--- a/cmd/iamctl/internal/connection/args.go
+++ b/cmd/iamctl/internal/connection/args.go
@@ -105,7 +105,7 @@ type tokenCredentials string
 
 func (t tokenCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
 	return map[string]string{
-		"authorization": "bearer " + string(t),
+		"authorization": "Bearer " + string(t),
 	}, nil
 }
 


### PR DESCRIPTION
ESPv2 requires the prefix to be capitalized.
