### PR TITLE
fix(iamgoogle): recognize ID tokens without https:// in issuer

### DIFF
--- a/iamgoogle/idtoken.go
+++ b/iamgoogle/idtoken.go
@@ -1,14 +1,13 @@
 package iamgoogle
 
 import (
+	"strings"
+
 	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
 )
-
-// Issuer is the issuer of Google ID tokens.
-const Issuer = "https://accounts.google.com"
 
 // IsGoogleIdentityToken returns true if the JWT payload is from a Google ID token.
 // See: https://developers.google.com/identity/protocols/oauth2/openid-connect
 func IsGoogleIdentityToken(token *iamv1.IdentityToken) bool {
-	return token.Iss == Issuer
+	return strings.TrimPrefix(token.Iss, "https://") == "accounts.google.com"
 }

--- a/iamgoogle/idtoken_test.go
+++ b/iamgoogle/idtoken_test.go
@@ -1,0 +1,15 @@
+package iamgoogle
+
+import (
+	"testing"
+
+	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
+	"gotest.tools/v3/assert"
+)
+
+func TestIsGoogleIdentityToken(t *testing.T) {
+	assert.Assert(t, IsGoogleIdentityToken(&iamv1.IdentityToken{Iss: "https://accounts.google.com"}))
+	assert.Assert(t, IsGoogleIdentityToken(&iamv1.IdentityToken{Iss: "accounts.google.com"}))
+	assert.Assert(t, !IsGoogleIdentityToken(&iamv1.IdentityToken{Iss: "foo.com"}))
+	assert.Assert(t, !IsGoogleIdentityToken(&iamv1.IdentityToken{Iss: "http://accounts.google.com"}))
+}


### PR DESCRIPTION
Some ID tokens are issued without https:// prefix, and this patch
enables the library to recognize them correctly.
