### PR TITLE
fix: simplify CEL permission test functions

### DIFF
--- a/iamcel/testall.go
+++ b/iamcel/testall.go
@@ -81,11 +81,8 @@ func NewTestAllFunctionImplementation(
 				}
 				return types.NewErr("test: error testing permission: %v", err)
 			} else {
-				if len(result) != len(resources) {
-					return types.False
-				}
-				for _, ok := range result {
-					if !ok {
+				for _, resource := range resources {
+					if !result[resource] {
 						return types.False
 					}
 				}

--- a/iamcel/testany.go
+++ b/iamcel/testany.go
@@ -81,11 +81,8 @@ func NewTestAnyFunctionImplementation(
 				}
 				return types.NewErr("test: error testing permission: %v", err)
 			} else {
-				if len(result) != len(resources) {
-					return types.False
-				}
-				for _, ok := range result {
-					if ok {
+				for _, resource := range resources {
+					if result[resource] {
 						return types.True
 					}
 				}


### PR DESCRIPTION
No need to check length of result when looping through and testing the
original resources is sufficient.
