### PR TITLE
fix(protoc-gen-go-iam): always generate long-running methods

### DIFF
--- a/cmd/protoc-gen-go-iam/internal/geniam/authorization.go
+++ b/cmd/protoc-gen-go-iam/internal/geniam/authorization.go
@@ -119,7 +119,7 @@ func (c authorizationCodeGenerator) generateStruct(g *protogen.GeneratedFile) {
 		}
 		g.P("}")
 	}
-	if options := getLongRunningOperationsAuthorizationOptions(c.service); options != nil && options.GetBefore() {
+	if options := getLongRunningOperationsAuthorizationOptions(c.service); options != nil {
 		c.generateLongRunningOperationMethod(g, options, "ListOperations", g.QualifiedGoIdent(protogen.GoIdent{
 			GoImportPath: "google.golang.org/genproto/googleapis/longrunning",
 			GoName:       "ListOperationsResponse",


### PR DESCRIPTION
No matter the authorization implementation (none, before, custom).
