### PR TITLE
feat: recognize multiple types of google service accounts

### DIFF
--- a/iamgoogle/payload.go
+++ b/iamgoogle/payload.go
@@ -31,5 +31,5 @@ func IsGoogleCloudServiceAccountEmail(payload *idtoken.Payload) bool {
 		return false
 	}
 	email, ok := Email(payload)
-	return ok && strings.HasSuffix(email, ".iam.gserviceaccount.com")
+	return ok && strings.HasSuffix(email, ".gserviceaccount.com")
 }

--- a/iamgoogle/payload_test.go
+++ b/iamgoogle/payload_test.go
@@ -1,0 +1,47 @@
+package iamgoogle
+
+import (
+	"testing"
+
+	"google.golang.org/api/idtoken"
+	"gotest.tools/v3/assert"
+)
+
+func TestContextMemberResolver_IsGoogleServiceAccount(t *testing.T) {
+	tests := []struct {
+		email string
+		valid bool
+	}{
+		{
+			email: "default-compute@developer.gserviceaccount.com",
+			valid: true,
+		},
+		{
+			email: "user-managed@einride.iam.gserviceaccount.com",
+			valid: true,
+		},
+		{
+			email: "google-managed@@cloudservices.gserviceaccount.com",
+			valid: true,
+		},
+		{
+			email: "missing-dot@gserviceaccount.com",
+			valid: false,
+		},
+		{
+			email: "any@example.com",
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		claims := map[string]interface{}{
+			"email_verified": true,
+			"email":          tt.email,
+		}
+
+		assert.Equal(t, IsGoogleCloudServiceAccountEmail(&idtoken.Payload{
+			Claims: claims,
+		}), tt.valid)
+	}
+}


### PR DESCRIPTION
Currently this function only recognizes user-managed service accounts. This would not capture default service accounts or google managed service accounts. 

https://cloud.google.com/iam/docs/service-accounts#types

