### PR TITLE
feat: use stale reads for permissiontests

### DIFF
--- a/iamspanner/server_bindings_read.go
+++ b/iamspanner/server_bindings_read.go
@@ -3,6 +3,7 @@ package iamspanner
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/spanner"
 	"go.einride.tech/aip/resourcename"
@@ -101,7 +102,7 @@ func (s *IAMServer) ReadBindingsByMembersAndPermissions(
 	permissions []string,
 	fn func(ctx context.Context, resource string, role *admin.Role, member string) error,
 ) error {
-	tx := s.client.Single()
+	tx := s.client.Single().WithTimestampBound(spanner.MaxStaleness(5 * time.Second))
 	defer tx.Close()
 	return s.ReadBindingsByMembersAndPermissionsInTransaction(ctx, tx, members, permissions, fn)
 }


### PR DESCRIPTION
In order to allow the permission tests to avoid
blocking with strong reads. This setting will
allow spanner to choose an appropriate read
timestamp within a bound of 5 seconds.

Spanner internally tries to use the freshest timestamp
it can within the bounds. This should reduce latency on
reads.

https://cloud.google.com/spanner/docs/timestamp-bounds