### PR TITLE
fix: improve sequencing of proto targets

### DIFF
--- a/.sage/proto.go
+++ b/.sage/proto.go
@@ -12,8 +12,9 @@ import (
 type Proto sg.Namespace
 
 func (Proto) All(ctx context.Context) error {
-	sg.Deps(ctx, Proto.BufFormat, Proto.BufLint, Proto.BufBreaking, Proto.APILinterLint, Proto.BufGenerate)
-	sg.Deps(ctx, Proto.APILinterLint, Proto.BufGenerate)
+	sg.Deps(ctx, Proto.BufFormat, Proto.BufLint, Proto.BufBreaking)
+	sg.Deps(ctx, Proto.APILinterLint)
+	sg.Deps(ctx, Proto.BufGenerate)
 	sg.Deps(ctx, Proto.BufGenerateExample)
 	return nil
 }

--- a/iamauthz/after.go
+++ b/iamauthz/after.go
@@ -68,7 +68,7 @@ func (a *AfterMethodAuthorization) AuthorizeRequestAndResponse(
 	if err != nil {
 		return nil, err
 	}
-	val, _, err := a.program.Eval(map[string]interface{}{
+	val, _, err := a.program.ContextEval(ctx, map[string]interface{}{
 		"caller":   caller,
 		"request":  request,
 		"response": response,

--- a/iamauthz/before.go
+++ b/iamauthz/before.go
@@ -67,7 +67,7 @@ func (a *BeforeMethodAuthorization) AuthorizeRequest(
 	if err != nil {
 		return nil, err
 	}
-	val, _, err := a.program.Eval(map[string]interface{}{
+	val, _, err := a.program.ContextEval(ctx, map[string]interface{}{
 		"caller":  caller,
 		"request": request,
 	})


### PR DESCRIPTION
Buf can sometimes time out if you try and do too many things
concurrently that require module downloading.