### PR TITLE
feat(iamcel): add test_namespace function

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Tests `caller`s permissions against all `resources`. This test asserts that the 
 
 Tests `caller`s permissions against any `resources`. This test asserts that the caller has the permission against at least one resource.
 
+#### [`test_namespace(caller Caller, namespace string, resource string) bool`](./iamcel/test_namespace.go)
+
+Tests `caller`s permissions against `resource` under the namespace `namespace`.
+
+Namespaces are currently implemented as implicit resource parents, meaning that permissions are tested on the resource name `{namespace}/{resource}`.
+
 #### [`ancestor(resource string, pattern string) string`](./iamcel/ancestor.go)
 
 Resolves an ancestor of `resource` using `pattern`. An input of `ancestor("foo/1/bar/2", "foo/{foo}")` will yield the result `"foo/1"`.

--- a/iamauthz/after.go
+++ b/iamauthz/after.go
@@ -45,6 +45,7 @@ func NewAfterMethodAuthorization(
 			iamcel.NewTestFunctionImplementation(options, permissionTester),
 			iamcel.NewTestAllFunctionImplementation(options, permissionTester),
 			iamcel.NewTestAnyFunctionImplementation(options, permissionTester),
+			iamcel.NewTestNamespaceFunctionImplementation(options, permissionTester),
 			iamcel.NewAncestorFunctionImplementation(),
 		),
 	)

--- a/iamauthz/before.go
+++ b/iamauthz/before.go
@@ -45,6 +45,7 @@ func NewBeforeMethodAuthorization(
 			iamcel.NewTestFunctionImplementation(options, permissionTester),
 			iamcel.NewTestAllFunctionImplementation(options, permissionTester),
 			iamcel.NewTestAnyFunctionImplementation(options, permissionTester),
+			iamcel.NewTestNamespaceFunctionImplementation(options, permissionTester),
 			iamcel.NewAncestorFunctionImplementation(),
 		),
 	)

--- a/iamcel/after.go
+++ b/iamcel/after.go
@@ -25,6 +25,7 @@ func NewAfterEnv(method protoreflect.MethodDescriptor) (*cel.Env, error) {
 			NewTestFunctionDeclaration(),
 			NewTestAllFunctionDeclaration(),
 			NewTestAnyFunctionDeclaration(),
+			NewTestNamespaceFunctionDeclaration(),
 			NewAncestorFunctionDeclaration(),
 		),
 	)

--- a/iamcel/before.go
+++ b/iamcel/before.go
@@ -24,6 +24,7 @@ func NewBeforeEnv(method protoreflect.MethodDescriptor) (*cel.Env, error) {
 			NewTestFunctionDeclaration(),
 			NewTestAllFunctionDeclaration(),
 			NewTestAnyFunctionDeclaration(),
+			NewTestNamespaceFunctionDeclaration(),
 			NewAncestorFunctionDeclaration(),
 		),
 	)

--- a/iamcel/test_namespace.go
+++ b/iamcel/test_namespace.go
@@ -1,0 +1,98 @@
+package iamcel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+	"go.einride.tech/iam/iampermission"
+	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestNamespaceFunction is the name of the test_namespace function.
+const TestNamespaceFunction = "test_namespace"
+
+// permission test function overloads.
+const testNamespaceFunctionOverload = "test_namespace_caller_string_string_bool"
+
+// NewTestNamespaceFunctionDeclaration creates a new declaration for the test_namespace function.
+func NewTestNamespaceFunctionDeclaration() *expr.Decl {
+	return decls.NewFunction(
+		TestNamespaceFunction,
+		decls.NewOverload(
+			testNamespaceFunctionOverload,
+			[]*expr.Type{
+				decls.NewObjectType(string((&iamv1.Caller{}).ProtoReflect().Descriptor().FullName())),
+				decls.String,
+				decls.String,
+			},
+			decls.Bool,
+		),
+	)
+}
+
+// NewTestNamespaceFunctionImplementation creates a new implementation for the test_namespace function.
+func NewTestNamespaceFunctionImplementation(
+	options *iamv1.MethodAuthorizationOptions,
+	tester PermissionTester,
+) *functions.Overload {
+	return &functions.Overload{
+		Operator: testNamespaceFunctionOverload,
+		Function: func(values ...ref.Val) ref.Val {
+			if len(values) != 3 {
+				return types.NewErr("test: unexpected number of arguments, expected 3 but got %d", len(values))
+			}
+			caller, ok := values[0].Value().(*iamv1.Caller)
+			if !ok {
+				return types.NewErr("test: unexpected type of arg 1, expected %T but got %T", &iamv1.Caller{}, values[0].Value())
+			}
+			namespace, ok := values[1].Value().(string)
+			if !ok {
+				return types.NewErr("test: unexpected type of arg 2, expected string but got %T", values[1].Value())
+			}
+			resource, ok := values[2].Value().(string)
+			if !ok {
+				return types.NewErr("test: unexpected type of arg 3, expected string but got %T", values[2].Value())
+			}
+			permission, ok := iampermission.ResolveMethodPermission(options, resource)
+			if !ok {
+				return types.NewErr("%s: no permission configured for resource '%s'", codes.PermissionDenied, resource)
+			}
+			// TODO: When cel-go supports async functions, use the caller context here.
+			ctx := context.Background()
+			if caller.GetContext().GetDeadline() != nil {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, caller.GetContext().GetDeadline().AsTime())
+				defer cancel()
+			}
+
+			namespacedResource := namespaceResource(namespace, resource)
+			result, err := tester.TestPermissions(ctx, caller, map[string]string{namespacedResource: permission})
+			switch {
+			case err != nil:
+				if s, ok := status.FromError(err); ok {
+					return types.NewErr("%s: %s", s.Code(), s.Message())
+				}
+				return types.NewErr("test: error testing permission '%s': %v", permission, err)
+			case !result[namespacedResource]:
+				return types.False
+			default:
+				return types.True
+			}
+		},
+	}
+}
+
+func namespaceResource(namespace, resource string) string {
+	for len(namespace) > 1 && strings.HasSuffix(namespace, "/") {
+		namespace = strings.TrimSuffix(namespace, "/")
+	}
+	return fmt.Sprintf("%s/%s", namespace, resource)
+}

--- a/iamcel/test_namespace_test.go
+++ b/iamcel/test_namespace_test.go
@@ -1,0 +1,137 @@
+package iamcel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	iamv1 "go.einride.tech/iam/proto/gen/einride/iam/v1"
+	"google.golang.org/protobuf/testing/protocmp"
+	"gotest.tools/v3/assert"
+)
+
+func TestTestNamespaceFunction(t *testing.T) {
+	caller := (&iamv1.Caller{}).ProtoReflect().Descriptor()
+	dependencies, err := collectDependencies(caller)
+	assert.NilError(t, err)
+	env, err := cel.NewEnv(
+		cel.TypeDescs(dependencies),
+		cel.Variable("caller", cel.ObjectType(string(caller.FullName()))),
+		cel.Declarations(NewTestNamespaceFunctionDeclaration()),
+	)
+	assert.NilError(t, err)
+
+	const (
+		resource       = "resource/1234"
+		otherResource  = "resources/2345"
+		namespace      = "namespace/5678"
+		otherNamespace = "namespace/6789"
+		permission     = "resource.permission"
+	)
+
+	authzOptions := &iamv1.MethodAuthorizationOptions{
+		Permissions: &iamv1.MethodAuthorizationOptions_Permission{
+			Permission: permission,
+		},
+	}
+
+	t.Run("allowed namespace and resource", func(t *testing.T) {
+		tester := &mockTester{
+			t: t,
+			expectResources: map[string]string{
+				namespace + "/" + resource: permission,
+			},
+			returnMap: map[string]bool{
+				namespace + "/" + resource: true,
+			},
+		}
+		ast, issues := env.Compile(
+			fmt.Sprintf(
+				`test_namespace(caller, '%s', '%s')`,
+				namespace,
+				resource,
+			),
+		)
+		assert.NilError(t, issues.Err())
+		//nolint: staticcheck // TODO: migrate to new top-level API
+		program, err := env.Program(ast, cel.Functions(NewTestNamespaceFunctionImplementation(authzOptions, tester)))
+		assert.NilError(t, err)
+		result, _, err := program.Eval(map[string]interface{}{"caller": &iamv1.Caller{}})
+		assert.NilError(t, err)
+		assert.Equal(t, true, result.Value().(bool))
+	})
+
+	t.Run("disallowed namespace", func(t *testing.T) {
+		tester := &mockTester{
+			t: t,
+			expectResources: map[string]string{
+				otherNamespace + "/" + resource: permission,
+			},
+			returnMap: map[string]bool{},
+		}
+		ast, issues := env.Compile(
+			fmt.Sprintf(
+				`test_namespace(caller, '%s', '%s')`,
+				otherNamespace,
+				resource,
+			),
+		)
+		assert.NilError(t, issues.Err())
+		//nolint: staticcheck // TODO: migrate to new top-level API
+		program, err := env.Program(ast, cel.Functions(NewTestNamespaceFunctionImplementation(authzOptions, tester)))
+		assert.NilError(t, err)
+		result, _, err := program.Eval(map[string]interface{}{"caller": &iamv1.Caller{}})
+		assert.NilError(t, err)
+		assert.Equal(t, false, result.Value().(bool))
+	})
+
+	t.Run("disallowed resource", func(t *testing.T) {
+		tester := &mockTester{
+			t: t,
+			expectResources: map[string]string{
+				namespace + "/" + otherResource: permission,
+			},
+			returnMap: map[string]bool{},
+		}
+		ast, issues := env.Compile(
+			fmt.Sprintf(
+				`test_namespace(caller, '%s', '%s')`,
+				namespace,
+				otherResource,
+			),
+		)
+		assert.NilError(t, issues.Err())
+		//nolint: staticcheck // TODO: migrate to new top-level API
+		program, err := env.Program(ast, cel.Functions(NewTestNamespaceFunctionImplementation(authzOptions, tester)))
+		assert.NilError(t, err)
+		result, _, err := program.Eval(map[string]interface{}{"caller": &iamv1.Caller{}})
+		assert.NilError(t, err)
+		assert.Equal(t, false, result.Value().(bool))
+	})
+}
+
+type mockTester struct {
+	t               *testing.T
+	expectResources map[string]string
+	returnMap       map[string]bool
+	returnErr       error
+}
+
+func (m *mockTester) TestPermissions(
+	_ context.Context,
+	caller *iamv1.Caller,
+	resources map[string]string,
+) (map[string]bool, error) {
+	assert.DeepEqual(m.t, caller, &iamv1.Caller{}, protocmp.Transform())
+	assert.DeepEqual(m.t, resources, m.expectResources)
+	return m.returnMap, m.returnErr
+}
+
+func TestNamespaceResource(t *testing.T) {
+	assert.Equal(t, namespaceResource("namespace", "resource"), "namespace/resource")
+	assert.Equal(t, namespaceResource("namespace/1", "resource"), "namespace/1/resource")
+	assert.Equal(t, namespaceResource("namespace/1/", "resource"), "namespace/1/resource")
+	assert.Equal(t, namespaceResource("namespace/1//", "resource"), "namespace/1/resource")
+	assert.Equal(t, namespaceResource("namespace/1////", "resource"), "namespace/1/resource")
+}


### PR DESCRIPTION
The test_namespace function tests a callers permissions against resource under a namespace.

Namespaces are currently implemented as implicit resource parents, meaning that permissions are tested on the resource name `{namespace}/{resource}`.